### PR TITLE
Update the zpr storage mount so they use sec=none

### DIFF
--- a/manifests/offsite.pp
+++ b/manifests/offsite.pp
@@ -12,7 +12,7 @@ class zpr::offsite (
   if $env_tag {
     File  <<| tag == $readonly_tag and tag == 'zpr_vol' and tag == $env_tag |>>
     Mount <<| tag == $readonly_tag and tag == 'zpr_vol' and tag == $env_tag |>> {
-      options => 'ro'
+      options => 'defaults,ro,sec=none'
     }
     Zpr::Duplicity <<| tag == $readonly_tag and tag == 'zpr_duplicity' and tag == $env_tag |>>
   }

--- a/manifests/rsync.pp
+++ b/manifests/rsync.pp
@@ -8,7 +8,7 @@ define zpr::rsync (
   $task_spooler   = '/usr/bin/tsp -E',
   $rsync          = '/usr/bin/rsync',
   $rsync_options  = 'rlpgoDShpEi',
-  $delete         = '--delete-after',
+  $delete         = '--delete-after --delete-excluded',
   $rsync_path     = 'sudo rsync',
   $user           = 'zpr_proxy',
   $hour           = '0',

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -14,7 +14,7 @@ class zpr::worker (
     File  <<| tag == $worker_tag and tag == $env_tag and tag == 'zpr_rsync' |>>
     File  <<| tag == $worker_tag and tag == $env_tag and tag == 'zpr_vol' |>>
     Mount <<| tag == $worker_tag and tag == $env_tag and tag == 'zpr_vol' |>> {
-      options => 'rw'
+      options => 'defaults,sec=none'
     }
     Cron  <<| tag == $worker_tag and tag == $env_tag and tag == 'zpr_rsync' |>>
     Concat::Fragment <<| tag == $worker_tag and tag == $env_tag and tag == 'zpr_sshkey' |>>


### PR DESCRIPTION
  This commit updates the mount resources that are exported by zpr to
  make sure they mount using the none sec option.  This is how Linux
  enable anonymous mounting of NFS volumes.

  Without this commit, uids matter because the sys sec type is used.
  Since our hosts are not members of LDAP UID alignment is
  unpredictable.
