### PR TITLE
Make sure delete also means delete excluded

### DIFF
--- a/manifests/rsync.pp
+++ b/manifests/rsync.pp
@@ -8,7 +8,7 @@ define zpr::rsync (
   $task_spooler   = '/usr/bin/tsp -E',
   $rsync          = '/usr/bin/rsync',
   $rsync_options  = 'rlpgoDShpEi',
-  $delete         = '--delete-after',
+  $delete         = '--delete-after --delete-excluded',
   $rsync_path     = 'sudo rsync',
   $user           = 'zpr_proxy',
   $hour           = '0',


### PR DESCRIPTION
  This adds the --delete-excluded option so that files that are excluded
  from the rsync job are deleted.  This is needed so that when files are
  no longer required, they are removed from the backup rotation and
  staging directories.

  Without this, backend storage nodes will keep unwanted files around
  forever.
