### PR TITLE
Modify another mount options override.

### DIFF
--- a/manifests/offsite.pp
+++ b/manifests/offsite.pp
@@ -19,7 +19,7 @@ class zpr::offsite (
   else {
     File  <<| tag == $readonly_tag and tag == 'zpr_vol' |>>
     Mount <<| tag == $readonly_tag and tag == 'zpr_vol' |>> {
-      options => 'ro'
+      options => 'defaults,ro,sec=none'
     }
     Zpr::Duplicity <<| tag == $readonly_tag and tag == 'zpr_duplicity' |>>
   }

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -22,7 +22,7 @@ class zpr::worker (
   else {
     File  <<| tag == $worker_tag and tag == 'zpr_rsync' |>>
     File  <<| tag == $worker_tag and tag == 'zpr_vol' |>>
-    Mount <<| tag == $worker_tag and tag == 'zpr_vol' |>> { options => 'rw' }
+    Mount <<| tag == $worker_tag and tag == 'zpr_vol' |>> { options => 'defaults,sec=none' }
     Cron  <<| tag == $worker_tag and tag == 'zpr_rsync' |>>
     Concat::Fragment <<| tag == $worker_tag and tag == 'zpr_sshkey' |>>
   }


### PR DESCRIPTION
  This commit makes sure both places where the options parameter on
  mount is overridden is set to use the same options.

  Without this, NFS mounts on proxies mount improperly.
