### PR TITLE
(OPS-7070) Set default env tag

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,7 +8,7 @@ class zpr (
   $storage            = undef,
   $worker_tag         = undef,
   $readonly_tag       = undef,
-  $env_tag            = undef,
+  $env_tag            = 'default_env_tag',
   $backup_dir         = undef,
   $pub_key            = undef,
   $sanity_check       = undef,


### PR DESCRIPTION
Set a default environment tag to work around a compile failure caused by the omission in 2015.2.
