### PR TITLE
Set env_tag to a default

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -193,7 +193,7 @@ define zpr::job (
   $target                = undef,
   $rsync_options         = undef,
   $exclude               = undef,
-  $env_tag               = $::current_environment,
+  $env_tag               = undef,
   $anon_user_id          = '50555',
   $nosub                 = true,
   $prepend_title         = false
@@ -203,6 +203,12 @@ define zpr::job (
     $utitle = "${::certname}_${title}"
   } else {
     $utitle = $title
+  }
+
+  if $env_tag {
+    $_env_tag = $env_tag
+  } else {
+    $_env_tag = $::zpr::params::env_tag
   }
 
   $vol_name  = "${zpool}/${utitle}"

--- a/manifests/rsync.pp
+++ b/manifests/rsync.pp
@@ -16,7 +16,7 @@ define zpr::rsync (
   $key_name       = 'id_rsa',
   $ssh_options    = ['SendEnv zpr_rsync_cmd', 'BatchMode yes'],
   $worker_tag     = undef,
-  $env_tag        = $::current_environment,
+  $env_tag        = undef,
   $exclude        = undef
 ) {
 
@@ -46,6 +46,12 @@ define zpr::rsync (
       }
     }
 
+    if $env_tag {
+      $_env_tag = $env_tag
+    } else {
+      $_env_tag = $::zpr::params::env_tag
+    }
+
     $rsync_cmd = [
       $task_spooler,
       '/bin/bash -c',
@@ -62,7 +68,7 @@ define zpr::rsync (
       user    => $user,
       hour    => $hour,
       minute  => $minute,
-      tag     => [ $worker_tag, $env_tag, 'zpr_rsync'],
+      tag     => [ $worker_tag, $_env_tag, 'zpr_rsync'],
     }
 
     @@file { "${permitted_commands}/${title}":
@@ -70,7 +76,7 @@ define zpr::rsync (
       group   => $user,
       mode    => '0400',
       content => template('zpr/rsync.erb'),
-      tag     => [ $worker_tag, $env_tag, $source_url, 'zpr_rsync' ]
+      tag     => [ $worker_tag, $_env_tag, $source_url, 'zpr_rsync' ]
     }
   }
   else {


### PR DESCRIPTION
This commit updates env_tag to be set to the default for clients unless explicitly overridden. Without this change the prior update to create default_env_tag conflicts with the fact that jobs generated a env_tag of current_environment.
