### PR TITLE
Remove collection based on environment

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -199,21 +199,15 @@ define zpr::job (
   $prepend_title         = false
 ) {
 
+  include zpr::user
+
   if $prepend_title {
     $utitle = "${::certname}_${title}"
   } else {
     $utitle = $title
   }
 
-  if $env_tag {
-    $_env_tag = $env_tag
-  } else {
-    $_env_tag = $::zpr::params::env_tag
-  }
-
   $vol_name  = "${zpool}/${utitle}"
-
-  include zpr::user
 
   if $title =~ /(\s|=|,|@)/ {
     fail("Backup resource ${title} cannot contain whitespace or special characters")

--- a/manifests/offsite.pp
+++ b/manifests/offsite.pp
@@ -1,7 +1,6 @@
 # A class to mount nfs volumes read-only for exporting as backups
 class zpr::offsite (
-  $readonly_tag = $zpr::params::readonly_tag,
-  $env_tag      = $zpr::params::env_tag
+  $readonly_tag = $zpr::params::readonly_tag
 ) inherits zpr::params {
 
   include zpr::user
@@ -9,18 +8,9 @@ class zpr::offsite (
   include zpr::task_spooler
   include zpr::lockfile_progs
 
-  if $env_tag {
-    File  <<| tag == $readonly_tag and tag == 'zpr_vol' and tag == $env_tag |>>
-    Mount <<| tag == $readonly_tag and tag == 'zpr_vol' and tag == $env_tag |>> {
-      options => 'defaults,ro,sec=none'
-    }
-    Zpr::Duplicity <<| tag == $readonly_tag and tag == 'zpr_duplicity' and tag == $env_tag |>>
+  File  <<| tag == $readonly_tag and tag == 'zpr_vol' |>>
+  Mount <<| tag == $readonly_tag and tag == 'zpr_vol' |>> {
+    options => 'defaults,ro,sec=none'
   }
-  else {
-    File  <<| tag == $readonly_tag and tag == 'zpr_vol' |>>
-    Mount <<| tag == $readonly_tag and tag == 'zpr_vol' |>> {
-      options => 'defaults,ro,sec=none'
-    }
-    Zpr::Duplicity <<| tag == $readonly_tag and tag == 'zpr_duplicity' |>>
-  }
+  Zpr::Duplicity <<| tag == $readonly_tag and tag == 'zpr_duplicity' |>>
 }

--- a/manifests/rsync.pp
+++ b/manifests/rsync.pp
@@ -46,12 +46,6 @@ define zpr::rsync (
       }
     }
 
-    if $env_tag {
-      $_env_tag = $env_tag
-    } else {
-      $_env_tag = $::zpr::params::env_tag
-    }
-
     $rsync_cmd = [
       $task_spooler,
       '/bin/bash -c',
@@ -68,7 +62,7 @@ define zpr::rsync (
       user    => $user,
       hour    => $hour,
       minute  => $minute,
-      tag     => [ $worker_tag, $_env_tag, 'zpr_rsync'],
+      tag     => [ $worker_tag, 'zpr_rsync'],
     }
 
     @@file { "${permitted_commands}/${title}":
@@ -76,7 +70,7 @@ define zpr::rsync (
       group   => $user,
       mode    => '0400',
       content => template('zpr/rsync.erb'),
-      tag     => [ $worker_tag, $_env_tag, $source_url, 'zpr_rsync' ]
+      tag     => [ $worker_tag, $source_url, 'zpr_rsync' ]
     }
   }
   else {

--- a/manifests/rsync_cmd.pp
+++ b/manifests/rsync_cmd.pp
@@ -14,10 +14,5 @@ class zpr::rsync_cmd (
     content => template('zpr/run_backup.erb')
   }
 
-  if $env_tag {
-    File <<| tag == $::fqdn and tag == 'zpr_rsync' and tag == $env_tag |>>
-  }
-  else {
-    File <<| tag == $::fqdn and tag == 'zpr_rsync' |>>
-  }
+  File <<| tag == $::fqdn and tag == 'zpr_rsync' |>>
 }

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -1,19 +1,10 @@
 # Provides storage for zpr
 class zpr::storage (
-  $storage     = $zpr::params::storage,
-  $env_tag     = $zpr::params::env_tag,
+  $storage     = $zpr::params::storage
 ) inherits zpr::params {
 
-  if $env_tag {
-    Zfs           <<| tag == $storage and tag == 'zpr_vol' and tag == $env_tag |>>
-    Zfs::Share    <<| tag == $storage and tag == 'zpr_share' and tag == $env_tag |>>
-    Zfs::Snapshot <<| tag == $storage and tag == 'zpr_snapshot' and tag == $env_tag |>>
-    File          <<| tag == $storage and tag == 'zpr_vol' and tag == $env_tag |>>
-  }
-  else {
-    Zfs           <<| tag == $storage and tag == 'zpr_vol' |>>
-    Zfs::Share    <<| tag == $storage and tag == 'zpr_share' |>>
-    Zfs::Snapshot <<| tag == $storage and tag == 'zpr_snapshot' |>>
-    File          <<| tag == $storage and tag == 'zpr_vol' |>>
-  }
+  Zfs           <<| tag == $storage and tag == 'zpr_vol' |>>
+  Zfs::Share    <<| tag == $storage and tag == 'zpr_share' |>>
+  Zfs::Snapshot <<| tag == $storage and tag == 'zpr_snapshot' |>>
+  File          <<| tag == $storage and tag == 'zpr_vol' |>>
 }

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -67,7 +67,7 @@ class zpr::user (
       key     => $::zpr_ssh_pubkey,
       type    => 'ssh-rsa',
       user    => $user,
-      tag     => [ $env_tag, $worker_tag, 'zpr_ssh_authorized_key' ],
+      tag     => [ $worker_tag, 'zpr_ssh_authorized_key' ],
       options => [
         "command=\"${wrapper}\"",
         'no-X11-forwarding',
@@ -147,7 +147,7 @@ class zpr::user (
   @@concat::fragment { "${::certname}_ecdsakey":
     target  => $known_hosts,
     content => join( $ssh_key_concat, ' ' ),
-    tag     => [ $env_tag, $worker_tag, 'zpr_sshkey' ],
+    tag     => [ $worker_tag, 'zpr_sshkey' ],
   }
 
   Ssh_authorized_key <<| tag == $worker_tag and tag == 'zpr_ssh_authorized_key' |>> {

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -1,7 +1,6 @@
 # A class to collect tasks to orchestrate zpr backup jobs
 class zpr::worker (
-  $worker_tag = $zpr::params::worker_tag,
-  $env_tag    = $zpr::params::env_tag,
+  $worker_tag = $zpr::params::worker_tag
 ) inherits zpr::params {
 
   class { 'zpr::user': source_user => true }
@@ -10,20 +9,10 @@ class zpr::worker (
   include zpr::task_spooler
   include zpr::lockfile_progs
 
-  if $env_tag {
-    File  <<| tag == $worker_tag and tag == $env_tag and tag == 'zpr_rsync' |>>
-    File  <<| tag == $worker_tag and tag == $env_tag and tag == 'zpr_vol' |>>
-    Mount <<| tag == $worker_tag and tag == $env_tag and tag == 'zpr_vol' |>> {
-      options => 'defaults,sec=none'
-    }
-    Cron  <<| tag == $worker_tag and tag == $env_tag and tag == 'zpr_rsync' |>>
-    Concat::Fragment <<| tag == $worker_tag and tag == $env_tag and tag == 'zpr_sshkey' |>>
-  }
-  else {
-    File  <<| tag == $worker_tag and tag == 'zpr_rsync' |>>
-    File  <<| tag == $worker_tag and tag == 'zpr_vol' |>>
-    Mount <<| tag == $worker_tag and tag == 'zpr_vol' |>> { options => 'defaults,sec=none' }
-    Cron  <<| tag == $worker_tag and tag == 'zpr_rsync' |>>
-    Concat::Fragment <<| tag == $worker_tag and tag == 'zpr_sshkey' |>>
-  }
+  File  <<| tag == $worker_tag and tag == 'zpr_rsync' |>>
+  File  <<| tag == $worker_tag and tag == 'zpr_vol' |>>
+  Mount <<| tag == $worker_tag and tag == 'zpr_vol' |>> {
+    options => 'defaults,sec=none' }
+  Cron  <<| tag == $worker_tag and tag == 'zpr_rsync' |>>
+  Concat::Fragment <<| tag == $worker_tag and tag == 'zpr_sshkey' |>>
 }


### PR DESCRIPTION
This commit updates zpr to remove collection based on environment.
Without this change the addition of default_env_tag breaks collection in
some scenarios. Sufficient mechanisms to control components are provided
through the individual tags so it is not necessary to provide
environment based collection.
