### PR TITLE
Ensure no undef tags are set

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -213,8 +213,12 @@ define zpr::job (
     fail("Backup resource ${title} cannot contain whitespace or special characters")
   }
 
-  $storage_tags = [ $_env_tag, $storage ]
-  $readonly_tags = [ $_env_tag, $worker_tag, 'zpr_vol' ]
+  if $storage == undef {
+    fail("Zpr::Job[$title] parameter \$storage cannot be undef")
+  }
+
+  $storage_tags = [ $storage ]
+  $readonly_tags = delete_undef_values([ $worker_tag, 'zpr_vol' ])
 
   if $snapshot {
     @@zfs::snapshot { $utitle:
@@ -260,9 +264,9 @@ define zpr::job (
         key_id     => $gpg_key_id,
         keep       => $keep_s3,
         full_every => $full_every,
-        tag        => [ $_env_tag, $readonly_tag, 'zpr_duplicity' ]
+        tag        => delete_undef_values([ $readonly_tag, 'zpr_duplicity' ])
       }
-      $ship_offsite_tags = concat($readonly_tags, $readonly_tag)
+      $ship_offsite_tags = delete_undef_values(concat($readonly_tags, $readonly_tag))
     }
   }
   else { $ship_offsite_tags = $readonly_tags }

--- a/manifests/rsync.pp
+++ b/manifests/rsync.pp
@@ -62,7 +62,7 @@ define zpr::rsync (
       user    => $user,
       hour    => $hour,
       minute  => $minute,
-      tag     => [ $worker_tag, 'zpr_rsync'],
+      tag     => delete_undef_values([ $worker_tag, 'zpr_rsync']),
     }
 
     @@file { "${permitted_commands}/${title}":
@@ -70,7 +70,7 @@ define zpr::rsync (
       group   => $user,
       mode    => '0400',
       content => template('zpr/rsync.erb'),
-      tag     => [ $worker_tag, $source_url, 'zpr_rsync' ]
+      tag     => delete_undef_values([ $worker_tag, $source_url, 'zpr_rsync' ])
     }
   }
   else {

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -17,6 +17,10 @@ class zpr::user (
   $wrapper            = '/usr/bin/zpr_wrapper.py',
 ) inherits zpr::params {
 
+  if $user == undef {
+    fail('::zpr::user parameter $user cannot be undef')
+  }
+
   $known_hosts = "${home}/.ssh/known_hosts"
 
   $check_for_elements = [
@@ -67,7 +71,7 @@ class zpr::user (
       key     => $::zpr_ssh_pubkey,
       type    => 'ssh-rsa',
       user    => $user,
-      tag     => [ $worker_tag, 'zpr_ssh_authorized_key' ],
+      tag     => delete_undef_values([ $worker_tag, 'zpr_ssh_authorized_key' ]),
       options => [
         "command=\"${wrapper}\"",
         'no-X11-forwarding',
@@ -147,7 +151,7 @@ class zpr::user (
   @@concat::fragment { "${::certname}_ecdsakey":
     target  => $known_hosts,
     content => join( $ssh_key_concat, ' ' ),
-    tag     => [ $worker_tag, 'zpr_sshkey' ],
+    tag     => delete_undef_values([ $worker_tag, 'zpr_sshkey' ]),
   }
 
   Ssh_authorized_key <<| tag == $worker_tag and tag == 'zpr_ssh_authorized_key' |>> {


### PR DESCRIPTION
`undef` tags cause 'comparison of String with :undef failed' errors. This adds some validation and filters `undef` out of tag arrays where appropriate.

This also removes a few unused variables.
