### PR TITLE
Ensure no undef tags are set

### DIFF
--- a/manifests/rsync.pp
+++ b/manifests/rsync.pp
@@ -1,5 +1,6 @@
 # rsync job designed for use with zpr
 define zpr::rsync (
+  $worker_tag,
   $source_url,
   $files,
   $dest_folder    = "/srv/backup/${title}",
@@ -15,7 +16,6 @@ define zpr::rsync (
   $minute         = '15',
   $key_name       = 'id_rsa',
   $ssh_options    = ['SendEnv zpr_rsync_cmd', 'BatchMode yes'],
-  $worker_tag     = undef,
   $env_tag        = undef,
   $exclude        = undef
 ) {
@@ -27,6 +27,10 @@ define zpr::rsync (
   $ssh_options_a      = any2array($ssh_options)
   $ssh_options_j      = join($ssh_options_a, "' -o '")
   $ssh_options_f      = "-o '${ssh_options_j}'"
+
+  if ! $worker_tag {
+    fail( '$worker_tag must be set' )
+  }
 
   if $files != '' or $files {
     if ( is_array($files) ) {
@@ -62,7 +66,7 @@ define zpr::rsync (
       user    => $user,
       hour    => $hour,
       minute  => $minute,
-      tag     => [ $worker_tag, 'zpr_rsync'],
+      tag     => [ $worker_tag, 'zpr_rsync']
     }
 
     @@file { "${permitted_commands}/${title}":

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -29,6 +29,10 @@ class zpr::user (
     '/usr/bin/.*',
   ]
 
+  if ! $worker_tag {
+    fail( '$worker_tag must be set' )
+  }
+
   if $::sshecdsakey {
     $ssh_key_concat = [
       "${::fqdn},${::primary_ip}",
@@ -147,7 +151,7 @@ class zpr::user (
   @@concat::fragment { "${::certname}_ecdsakey":
     target  => $known_hosts,
     content => join( $ssh_key_concat, ' ' ),
-    tag     => [ $worker_tag, 'zpr_sshkey' ],
+    tag     => [ $worker_tag, 'zpr_sshkey' ]
   }
 
   Ssh_authorized_key <<| tag == $worker_tag and tag == 'zpr_ssh_authorized_key' |>> {


### PR DESCRIPTION
This commit removes remaining usage of $env_tag. Without this change
undef tags are set causing a failure when comparing string with :undef
because puppet 4 cannot handle this case. Additionally, a correction is
made to in line documentation to reference the correctly titeld default.
