### PR TITLE
Update killgpg to be more specific

### DIFF
--- a/templates/killgpg.erb
+++ b/templates/killgpg.erb
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-GPG=$(ps aux | grep [g]pg-agent | awk '$1 == <%= @uid %>' | awk '{print $2}')
+GPG=$(ps aux | grep "[g]pg-agent --allow-preset-passphrase" | awk '$1 == <%= @uid %> {print $2}')
 
 is_alive() {
   if [[ -z $GPG ]]


### PR DESCRIPTION
This commit updates the killgpg script to be more specific when locating the gpg agent. Without this change the methodology used does not distinguish between a running agent and a job running using the agent. Therefore, it will attempt to kill both.
