### PR TITLE
Update generate_ssh_key for greater flexibility

### DIFF
--- a/manifests/generate_ssh_key.pp
+++ b/manifests/generate_ssh_key.pp
@@ -1,19 +1,22 @@
 # A class that creates ssh keys without passphrases
 define zpr::generate_ssh_key (
   $home,
-  $user  = $title,
-  $group = $user,
-  $path  = '/usr/bin',
-  $bits  = '4096',
-  $gen   = true
+  $user       = $title,
+  $group      = $user,
+  $path       = '/usr/bin',
+  $bits       = '4096',
+  $gen        = true,
+  $create_dir = true
 ) {
 
   $generate_key = "sudo -u ${user} ssh-keygen -t rsa -b ${bits} -N \"\" -f ${home}/.ssh/id_rsa"
 
-  file { "${home}/.ssh":
-    ensure => directory,
-    owner  => $user,
-    group  => $group
+  if $create_dir {
+    file { "${home}/.ssh":
+      ensure => directory,
+      owner  => $user,
+      group  => $group
+    }
   }
 
   if $gen {
@@ -21,8 +24,7 @@ define zpr::generate_ssh_key (
       cwd     => $home,
       command => $generate_key,
       creates => "${home}/.ssh/id_rsa",
-      path    => '/usr/bin',
-      require => File["${home}/.ssh"]
+      path    => '/usr/bin'
     }
   }
 }


### PR DESCRIPTION
This commit updates generate_ssh_key in order to make directory creation
optional. Without this change the define cannot be used in a case where
the directory is already managed.
