### PR TITLE
Set tsp queue when value doesn't match

### DIFF
--- a/manifests/task_spooler.pp
+++ b/manifests/task_spooler.pp
@@ -30,4 +30,21 @@ class zpr::task_spooler (
       mode    => '0500',
       content => join( $tsp_options, "\n" )
   }
+
+  file { "${home}/check_slots":
+    owner   => $user,
+    group   => $user,
+    mode    => '0500',
+    content => join([
+      '#!/usr/bin/env bash',
+      '[[ $(tsp -S) -eq $1 ]]'
+    ], "\n")
+  }
+
+  exec { 'set_slots':
+    path    => '/bin:/usr/bin',
+    command => "tsp -S ${slots}",
+    unless  => "${home}/check_slots ${slots}",
+    user    => $user
+  }
 }


### PR DESCRIPTION
This commit sets the tsp queue via an exec when the queue size does not match what is configured. Without this change the .tsprc file is the only place this is set, which does not get checked upon first load of task spooler. THe result is that after a reboot, or upon first boot, the queue size can end up smaller than configured because the default size is one.
