### PR TITLE
Confine zpr_ssh_key fact

### DIFF
--- a/lib/facter/zpr_ssh_key.rb
+++ b/lib/facter/zpr_ssh_key.rb
@@ -1,5 +1,7 @@
 Facter.add(:zpr_ssh_pubkey) do
 
+  confine :kernel => ['Linux', 'SunOS']
+
   require 'etc'
 
   setcode do


### PR DESCRIPTION
This commit confines the zpr_ssh_key fact to Linux and SunOS kernels. Without this change the fact generates an issue on Windows hosts where it is not supported.
