### PR TITLE
Only mount volumes when running a job

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -163,7 +163,6 @@ define zpr::job (
   $mount_vol             = true,
   $share_nfs             = 'on',
   $files_source          = $::fqdn,
-  $worker_tag            = 'worker',
   $readonly_tag          = 'readonly',
   $snapshot              = 'on',
   $keep                  = '15', # 14 snapshots
@@ -183,6 +182,7 @@ define zpr::job (
   $snapshot_minute       = $minute,
   $snapshot_r_hour       = $hour,
   $snapshot_r_minute     = $minute,
+  $worker_tag            = undef,
   $s3_target             = undef,
   $gpg_key_id            = undef, #toremove
   $compression           = undef,
@@ -281,8 +281,7 @@ define zpr::job (
     }
 
     @@mount { "${backup_dir}/${utitle}":
-      ensure  => mounted,
-      atboot  => true,
+      ensure  => present,
       fstype  => 'nfs',
       target  => '/etc/fstab',
       device  => "${storage}:/${vol_name}",

--- a/manifests/offsite.pp
+++ b/manifests/offsite.pp
@@ -1,6 +1,6 @@
 # A class to mount nfs volumes read-only for exporting as backups
 class zpr::offsite (
-  $readonly_tag = $zpr::params::readonly_tag
+  $readonly_tag = $::zpr::params::readonly_tag
 ) inherits zpr::params {
 
   include zpr::user

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,8 +8,8 @@ class zpr::params inherits zpr{
   $gid   = pick($globals_gid, $uid)
 
   # Tag configurations. Useful for collecting tags on workers
-  $worker_tag         = pick($globals_worker_tag, 'worker')
-  $readonly_tag       = pick($globals_readonly_tag, 'readonly')
+  $worker_tag         = pick($globals_worker_tag, $::hostname)
+  $readonly_tag       = pick($globals_readonly_tag, $::hostname)
   $storage            = $globals_storage
   $env_tag            = pick($globals_env_tag, 'default_env_tag')
   $sanity_check       = $globals_sanity_check

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -97,12 +97,24 @@ class zpr::user (
       content => join( $known_hosts_header, "\n" ),
       order   => 0
     }
+
+    sudo::entry { "${user}_sudo":
+      entry => "${user} ALL=(ALL) NOPASSWD:/usr/bin/rsync,/bin/mount,/bin/umount"
+    }
   }
   elsif $::hostname == $readonly_tag {
     $user_shell = '/bin/bash'
+
+    sudo::entry { "${user}_sudo":
+      entry => "${user} ALL=(ALL) NOPASSWD:/usr/bin/rsync,/bin/mount,/bin/umount"
+    }
   }
   else {
     $user_shell = '/bin/sh'
+
+    sudo::entry { "${user}_rsync":
+      entry => "${user} ALL=(ALL) NOPASSWD:/usr/bin/rsync"
+    }
 
     zpr::generate_ssh_key { $user:
       home => $home,
@@ -149,9 +161,6 @@ class zpr::user (
   }
 
   ssh::allowgroup { $group: }
-  sudo::entry { "${user}_rsync":
-    entry => "${user} ALL=(ALL) NOPASSWD:/usr/bin/rsync"
-  }
 
   @@concat::fragment { "${::certname}_ecdsakey":
     target  => $known_hosts,

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -1,6 +1,6 @@
 # A class to collect tasks to orchestrate zpr backup jobs
 class zpr::worker (
-  $worker_tag = $zpr::params::worker_tag
+  $worker_tag = $::zpr::params::worker_tag
 ) inherits zpr::params {
 
   class { 'zpr::user': source_user => true }

--- a/templates/run_backup.erb
+++ b/templates/run_backup.erb
@@ -4,10 +4,8 @@ set -e
 cmd=$1
 mount_path='<%= @backup_dir %>'
 cmd_path='<%= @permitted_commands %>'
-check_mount=$(stat -f -L -c %T ${mount_path}/${cmd} | sed 's/\///')
 cmd_="${cmd_path}/${cmd}"
 export zpr_rsync_cmd=$(cat $cmd_)
-create_lock=$(lockfile-create -r 0 ${mount_path}/${cmd}/zpr_rsync &> /dev/null ; echo $?)
 maintenance_mode='<%= @home %>/.maintenance_mode'
 
 cmd_empty() {
@@ -26,7 +24,24 @@ check_maintenance_mode() {
   fi
 }
 
+mount_volume() {
+  check_mount=$(sudo /bin/mount ${mount_path}/${cmd} > /dev/null 2>&1 ; echo $?)
+  if [[ $check_mount -eq 32 ]]
+  then
+    >&2 echo "Requested volume is already mounted"
+  elif [[ $check_mount -ne 0 ]]
+  then
+    >&2 echo "Cannot mount volume"
+    exit 3
+  fi
+}
+
+unmount_volume() {
+  sudo /bin/umount ${mount_path}/${cmd} > /dev/null 2>&1
+}
+
 path_is_nfs() {
+  check_mount=$(stat -f -L -c %T ${mount_path}/${cmd} | sed 's/\///')
   if [[ $check_mount != 'nfs' ]]
   then
     >&2 echo "Requested volume is not mounted"
@@ -35,6 +50,7 @@ path_is_nfs() {
 }
 
 check_lockfile() {
+  create_lock=$(lockfile-create -r 0 ${mount_path}/${cmd}/zpr_rsync &> /dev/null ; echo $?)
   if [[ $create_lock -ne 0 ]]
   then
     >&2 echo "A lock for $cmd exists"
@@ -61,13 +77,15 @@ check_if_exit_3() {
 main() {
   cmd_empty
   check_maintenance_mode
+  mount_volume
   path_is_nfs
   check_lockfile
   run_cmd
   remove_lock
+  unmount_volume
 }
 
-trap "remove_lock ; exit 255" SIGINT SIGQUIT SIGTERM
+trap "remove_lock && unmount_volume ; exit 255" SIGINT SIGQUIT SIGTERM
 trap "check_if_exit_3" EXIT
 
 main

--- a/templates/run_duplicity.erb
+++ b/templates/run_duplicity.erb
@@ -11,7 +11,6 @@ target=$2
 full_every=$3
 remove_older_than=$4
 maintenance_mode=${HOME}/.maintenance_mode
-check_mount=$(stat -f -L -c %T ${source_files})
 
 duplicity_backup() {
   /usr/bin/duplicity --encrypt-key ${key_id} --sign-key ${sign_key} --full-if-older-than ${full_every} ${source_files} ${target}
@@ -30,18 +29,49 @@ check_maintenance_mode() {
 }
 
 path_is_nfs() {
-  if [[ $check_mount != 'nfs' ]]
+  check_nfs_mount=$(stat -f -L -c %T ${source_files})
+  if [[ $check_nfs_mount != 'nfs' ]]
   then
     >&2 echo "Requested volume is not mounted"
     exit 2
   fi
 }
 
+mount_volume() {
+  check_mount=$(sudo /bin/mount ${source_files} > /dev/null 2>&1 ; echo $?)
+  if [[ $check_mount -eq 32 ]]
+  then
+    >&2 echo "Requested volume is already mounted"
+  elif [[ $check_mount -ne 0 ]]
+  then
+    >&2 echo "Cannot mount volume"
+    exit 3
+  fi
+}
+
+unmount_volume() {
+  sudo /bin/umount ${source_files} > /dev/null 2>&1
+}
+
+check_tsp() {
+  check_tsp=$(tsp | grep 'running' | grep ${source_files} | wc -l)
+  if [[ $check_tsp -gt 1 ]]
+  then
+    echo "A job is already running"
+    exit 1
+  fi
+}
+
 main() {
   check_maintenance_mode
+  check_tsp
+  mount_volume
   path_is_nfs
   duplicity_backup
   duplicity_cleanup
+  unmount_volume
 }
+
+trap "unmount_volume ; exit 255" SIGINT SIGQUIT SIGTERM
 
 main


### PR DESCRIPTION
This commit updates backup worker behavior to mount volumes at job
creation time. Without this change when a mount is created it is set to
ensure => mounted. The implication of this behavior is that when a
device backend is changed manual intervention is required to unmount the
currently used volume. This change supports placing the system into
maintenance mode, changing the backend storage configuration, and
letting the new volumes get mounted by the job as needed. The other
benefit of this change is it reduces load on the NFS server by
significantly reducing the number of simultaneous connections.
