### PR TITLE
Ensure volume is unmounted on exit

### DIFF
--- a/templates/run_backup.erb
+++ b/templates/run_backup.erb
@@ -71,6 +71,7 @@ check_if_exit_3() {
   if [[ $? -ne 3 ]]
   then
     remove_lock
+    unmount_volume
   fi
 }
 


### PR DESCRIPTION
This commit updates run_backup to ensure that the volume is unmounted even if rsync exit code is not 0. Without this change the volume is left mounted when a job exits with a result other than 0.
