### PR TITLE
Update run_backup to stop attempting unmount twice

### DIFF
--- a/templates/run_backup.erb
+++ b/templates/run_backup.erb
@@ -82,8 +82,6 @@ main() {
   path_is_nfs
   check_lockfile
   run_cmd
-  remove_lock
-  unmount_volume
 }
 
 trap "remove_lock && unmount_volume ; exit 255" SIGINT SIGQUIT SIGTERM


### PR DESCRIPTION
This commit updates run_backup to ensure that unmount is only run once. Without this change run_backup and remove_lock are specified in main and the function executed by trapping exit and results in exit code 1 on successful jobs.
